### PR TITLE
[[ LCIDLC CF types ]] Added non-releasing CF* types as input parameter f...

### DIFF
--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -124,6 +124,13 @@ enum
     // SN-2015-01-19: [[ Bug 14057 ]] Added forgotten C-char value type
     kMCExternalValueOptionAsCChar = 22,
     
+    // SN-2015-02-13:[[ Bug 14057 ]] Added CF-types (non-releasing)
+    kMCExternalValueOptionAsCFNumber = 23,
+    kMCExternalValueOptionAsCFString = 24,
+    kMCExternalValueOptionAsCFData = 25,
+    kMCExternalValueOptionAsCFArray = 26,
+    kMCExternalValueOptionAsCFDictionary = 27,
+    
 	kMCExternalValueOptionCaseSensitiveMask = 3 << 30,
 	kMCExternalValueOptionDefaultCaseSensitive = 0 << 30,
 	kMCExternalValueOptionCaseSensitive = 1 << 30,
@@ -2178,6 +2185,7 @@ static MCExternalError MCExternalVariableFetch(MCExternalVariableRef var, MCExte
     }
 #ifdef __HAS_CORE_FOUNDATION__
     case kMCExternalValueOptionAsNSNumber:
+    case kMCExternalValueOptionAsCFNumber:
     {
         CFNumberRef t_number;
         real64_t t_real;
@@ -2195,6 +2203,7 @@ static MCExternalError MCExternalVariableFetch(MCExternalVariableRef var, MCExte
         break;
     }
     case kMCExternalValueOptionAsNSString:
+    case kMCExternalValueOptionAsCFString:
     {
         MCAutoStringRef t_stringref;
         
@@ -2211,6 +2220,7 @@ static MCExternalError MCExternalVariableFetch(MCExternalVariableRef var, MCExte
         break;
     }
     case kMCExternalValueOptionAsNSData:
+    case kMCExternalValueOptionAsCFData:
     {
         MCAutoStringRef t_stringref;
         char *t_chars;
@@ -2231,6 +2241,7 @@ static MCExternalError MCExternalVariableFetch(MCExternalVariableRef var, MCExte
         break;
     }
     case kMCExternalValueOptionAsNSArray:
+    case kMCExternalValueOptionAsCFArray:
     {
         MCExternalError t_error;
         NSArray* t_value;
@@ -2257,6 +2268,7 @@ static MCExternalError MCExternalVariableFetch(MCExternalVariableRef var, MCExte
         return t_error;
     }
     case kMCExternalValueOptionAsNSDictionary:
+    case kMCExternalValueOptionAsCFDictionary:
     {
         MCExternalError t_error;
         NSDictionary* t_value;

--- a/lcidlc/include/LiveCode.h
+++ b/lcidlc/include/LiveCode.h
@@ -370,6 +370,19 @@ enum
 	
 	// The 'value' parameter is a pointer to a char variable (native encoding)
 	kLCValueOptionAsCChar = 22,
+    
+    // SN-2015-02-13: [[ ExternalsApiV6 ]] Added CF-type arguments, which
+    //  are NOT autoreleased when used as input
+    // The 'value' parameter is a pointer to an CFNumberRef variable.
+    kLCValueOptionAsCFNumber = 23,
+    // The 'value' parameter is a pointer to an CFStringRef variable.
+    kLCValueOptionAsCFString = 24,
+    // The 'value' parameter is a pointer to an CFDataRef variable.
+    kLCValueOptionAsCFData = 25,
+    // The 'value' parameter is a pointer to an CFArrayRef variable.
+    kLCValueOptionAsCFArray = 26,
+    // The 'value' parameter is a pointer to an CFDictionaryRef variable.
+    kLCValueOptionAsCFDictionary = 27,
 	
 	// Treat array keys as case-insensitive.
 	kLCValueOptionCaseSensitiveFalse = 0 << 30,

--- a/lcidlc/src/Support.mm
+++ b/lcidlc/src/Support.mm
@@ -140,6 +140,16 @@ enum
     kMCOptionAsObjcArray = 20,
     kMCOptionAsObjcDictionary = 21,
     
+    // SN-2015-02-13: [[ Bug 14057 ]] Added forgotten C-char type
+    kMCOptionAsCChar = 22,
+    
+    // SN-2015-02-13:[[ Bug 14057 ]] Added CF-types (non-releasing)
+    kMCOptionAsCFNumber = 23,
+    kMCOptionAsCFString = 24,
+    kMCOptionAsCFData = 25,
+    kMCOptionAsCFArray = 26,
+    kMCOptionAsCFDictionary = 27,
+    
 	kMCOptionNumberFormatDefault = 0 << 26,
 	kMCOptionNumberFormatDecimal = 1 << 26,
 	kMCOptionNumberFormatScientific = 2 << 26,


### PR DESCRIPTION
...or external functions
